### PR TITLE
Fix deprecation warning

### DIFF
--- a/src/module.json
+++ b/src/module.json
@@ -112,7 +112,7 @@
 		{
 			"name": "token-hotbar",
 			"label": "Token Hotbar Macros",
-			"entity": "Macro",
+            "type": "Macro",
 			"path": "packs/token-hotbar.db",
 			"module": "token-hotbar"
 		}


### PR DESCRIPTION
Replaced `"entity"` field with `"type"` for the compendium pack to get rid of the deprecation warning.